### PR TITLE
Improvements

### DIFF
--- a/RszTool/RszFile/PfbFile.cs
+++ b/RszTool/RszFile/PfbFile.cs
@@ -113,7 +113,17 @@ namespace RszTool
                 set => parentRef = value != null ? new(value) : null;
             }
 
-            public string? Name => (Instance?.GetFieldValue("v0") ?? Instance?.GetFieldValue("Name")) as string;
+            public string? Name
+            {
+                get => (Instance?.GetFieldValue("v0") ?? Instance?.GetFieldValue("Name")) as string;
+                set
+                {
+                    if (Instance != null && value != null)
+                    {
+                        Instance?.SetFieldValue("Name", value);
+                    }
+                }
+            }
 
             public int? ObjectId => Info?.Data.objectId;
 

--- a/RszTool/RszFile/RSZFile.cs
+++ b/RszTool/RszFile/RSZFile.cs
@@ -343,12 +343,6 @@ namespace RszTool
                         {
                             if (items[j] is int instanceId)
                             {
-                                if (instanceId >= instance.Index && field.IsTypeInferred)
-                                {
-                                    // TODO: may detect error, should roll back
-                                    field.type = RszFieldType.S32;
-                                    throw new RszRetryOpenException($"Detected {instance.RszClass.name}.{field.name} as Object before, but seems wrong");
-                                }
                                 items[j] = InstanceList[instanceId];
                                 InstanceUnflatten(InstanceList[instanceId]);
                             }
@@ -356,12 +350,6 @@ namespace RszTool
                     }
                     else if (instance.Values[i] is int instanceId)
                     {
-                        if (instanceId >= instance.Index && field.IsTypeInferred)
-                        {
-                            // TODO: may detect error, should roll back
-                            field.type = RszFieldType.S32;
-                            throw new RszRetryOpenException($"Detected {instance.RszClass.name}.{field.name} as Object before, but seems wrong");
-                        }
                         instance.Values[i] = InstanceList[instanceId];
                         InstanceUnflatten(InstanceList[instanceId]);
                     }

--- a/RszTool/RszFile/ScnFile.cs
+++ b/RszTool/RszFile/ScnFile.cs
@@ -167,7 +167,17 @@ namespace RszTool
                 set => parentRef = value != null ? new(value) : null;
             }
 
-            public string? Name => (Instance?.GetFieldValue("v0") ?? Instance?.GetFieldValue("Name")) as string;
+            public string? Name
+            {
+                get => (Instance?.GetFieldValue("v0") ?? Instance?.GetFieldValue("Name")) as string;
+                set
+                {
+                    if (Instance != null && value != null)
+                    {
+                        Instance?.SetFieldValue("Name", value);
+                    }
+                }
+            }
 
             public int? ObjectId => Info?.Data.objectId;
 


### PR DESCRIPTION
- ScnFile.GameObject.Name is not protected anymore 
- PfbFile.Name is not protected anymore
- Rollback some testings that caused the lib to crash with RE2 Meshes (Doing while loop otherwise was the thing to do until he was accepting the ScnFile)